### PR TITLE
remove extra circuit

### DIFF
--- a/qiskit_version/07_Variational_Circuits.ipynb
+++ b/qiskit_version/07_Variational_Circuits.ipynb
@@ -685,7 +685,6 @@
    "source": [
     "q = QuantumRegister(2)\n",
     "c = ClassicalRegister(2)\n",
-    "circuit = QuantumCircuit(q, c)\n",
     "\n",
     "# extract the optimal β's and γ's from the result.x attribute\n",
     "\n",


### PR DESCRIPTION
The variable circuit is defined twice, the second overrides the first (all happening in the same cell). I removed one.